### PR TITLE
Fix static CSS loading and support Pages deploy on main/master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Team Swiss Event Tracker</title>
+		<link rel="stylesheet" href="./src/styles.css" />
 	</head>
 	<body>
 		<div id="app"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import './styles.css';
 import { downloadPublishedHtml } from './lib/publish.js';
 import { loadState, saveState } from './lib/storage.js';
 import {


### PR DESCRIPTION
### Motivation
- Prevent a browser runtime error when unbuilt source is served directly by avoiding CSS imports from JS modules. 
- Ensure GitHub Pages production deploy workflow runs for repositories using either `main` or `master` as the default branch. 

### Description
- Add a standard stylesheet link to `index.html` with `<link rel="stylesheet" href="./src/styles.css" />` so static hosts can load CSS without Vite transforms. 
- Remove the `import './styles.css'` line from `src/main.js` to stop the browser from attempting to treat CSS as a JS module. 
- Update `.github/workflows/deploy.yml` to trigger on pushes to both `main` and `master` so the Pages deploy workflow runs for either default branch. 

### Testing
- Ran `npm run build` and the build completed successfully, producing hashed CSS/JS assets in `dist`.
- Ran `npm test` and all test suites passed.
- Verified `dist/index.html` references the built hashed assets and the app HTML renders with the stylesheet link present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba29a85fc83299bf65acefe84d584)