### PR TITLE
Add JSDoc annotations and enable V8 test coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "Unlicense",
 			"devDependencies": {
 				"@eslint/js": "^9.36.0",
+				"@vitest/coverage-v8": "^3.2.4",
 				"eslint": "^9.36.0",
 				"eslint-config-prettier": "^10.1.8",
 				"globals": "^16.4.0",
@@ -25,6 +26,20 @@
 			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "4.1.2",
@@ -60,6 +75,66 @@
 			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/@csstools/color-helpers": {
 			"version": "6.0.2",
@@ -149,7 +224,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -190,7 +264,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -864,12 +937,83 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
@@ -1253,6 +1397,40 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+			"integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ampproject/remapping": "^2.3.0",
+				"@bcoe/v8-coverage": "^1.0.2",
+				"ast-v8-to-istanbul": "^0.3.3",
+				"debug": "^4.4.1",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-lib-source-maps": "^5.0.6",
+				"istanbul-reports": "^3.1.7",
+				"magic-string": "^0.30.17",
+				"magicast": "^0.3.5",
+				"std-env": "^3.9.0",
+				"test-exclude": "^7.0.1",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "3.2.4",
+				"vitest": "3.2.4"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1374,7 +1552,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1419,6 +1596,19 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1451,6 +1641,25 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+			"integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1682,6 +1891,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/entities": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -1763,7 +1986,6 @@
 			"integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -2038,6 +2260,23 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2053,6 +2292,28 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2064,6 +2325,45 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+			"integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/globals": {
@@ -2101,6 +2401,13 @@
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
@@ -2177,6 +2484,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2204,6 +2521,76 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2230,7 +2617,6 @@
 			"integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@acemir/cssom": "^0.9.28",
 				"@asamuzakjp/dom-selector": "^6.7.6",
@@ -2360,6 +2746,34 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/magicast": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+			"integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.25.4",
+				"@babel/types": "^7.25.4",
+				"source-map-js": "^1.2.0"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.12.2",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -2378,6 +2792,16 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/ms": {
@@ -2463,6 +2887,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2509,6 +2940,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2539,7 +2994,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2690,6 +3144,19 @@
 				"node": ">=v12.22.7"
 			}
 		},
+		"node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2720,6 +3187,19 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2743,6 +3223,110 @@
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
@@ -2789,6 +3373,60 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/test-exclude": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+			"integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^10.4.1",
+				"minimatch": "^10.2.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/test-exclude/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/test-exclude/node_modules/brace-expansion": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/test-exclude/node_modules/minimatch": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+			"integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -2926,7 +3564,6 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -3180,6 +3817,101 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	"license": "Unlicense",
 	"devDependencies": {
 		"@eslint/js": "^9.36.0",
+		"@vitest/coverage-v8": "^3.2.4",
 		"eslint": "^9.36.0",
 		"eslint-config-prettier": "^10.1.8",
 		"globals": "^16.4.0",

--- a/src/lib/draftTables.js
+++ b/src/lib/draftTables.js
@@ -1,3 +1,9 @@
+/**
+ * Checks whether a value is a positive whole number.
+ *
+ * @param {unknown} value Candidate value.
+ * @returns {boolean} True when the input is a positive integer.
+ */
 function isPositiveInteger(value) {
 	return Number.isInteger(value) && value > 0;
 }
@@ -22,6 +28,13 @@ function teammatePairs(teamCount) {
 	return (teamCount * (teamCount - 1)) / 2;
 }
 
+/**
+ * Splits players across draft tables as evenly as possible.
+ *
+ * @param {number} totalPlayers Total seats to distribute.
+ * @param {number} tableCount Number of tables to create.
+ * @returns {number[]} Ordered list of table capacities.
+ */
 export function buildBalancedTableSizes(totalPlayers, tableCount) {
 	if (!isPositiveInteger(totalPlayers)) {
 		throw new Error('Total players must be a positive integer.');
@@ -39,6 +52,13 @@ export function buildBalancedTableSizes(totalPlayers, tableCount) {
 	);
 }
 
+/**
+ * Returns practical table-count options constrained by table-size bounds.
+ *
+ * @param {number} totalPlayers Total players to seat.
+ * @param {{minTableSize?: number, maxTableSize?: number}} [options] Size constraints.
+ * @returns {Array<{tableCount: number, tableSizes: number[]}>} Suggested layouts.
+ */
 export function listSuggestedDraftLayouts(
 	totalPlayers,
 	{ minTableSize = 4, maxTableSize = 10 } = {}
@@ -333,6 +353,14 @@ function summarizeAssignments(tables) {
 	return { sameTableTeammatePairs, maxTeammatesAtSingleTable };
 }
 
+/**
+ * Assigns players to draft tables while minimizing teammates sharing a table.
+ *
+ * @param {{teams: Array<{id: string, name: string, players: Array<{id: string, name: string}>}>}} event Event team roster.
+ * @param {number[]} tableSizes Capacities for each table.
+ * @param {{randomize?: boolean, rng?: () => number}} [options] Optional deterministic randomization controls.
+ * @returns {{tables: Array<{tableNumber: number, capacity: number, players: Array<object>}>, sameTableTeammatePairs: number}} Seating assignment summary.
+ */
 export function assignPlayersToDraftTables(event, tableSizes, options = {}) {
 	const { randomize = false, rng = Math.random } = options;
 

--- a/src/lib/playerDisplay.js
+++ b/src/lib/playerDisplay.js
@@ -1,7 +1,20 @@
+/**
+ * Normalizes free-form text input so downstream display helpers can operate on
+ * trimmed strings without repeatedly handling nullish values.
+ *
+ * @param {unknown} value Raw value from user input or persisted event data.
+ * @returns {string} A trimmed string representation of the provided value.
+ */
 function normalizeToken(value) {
 	return String(value ?? '').trim();
 }
 
+/**
+ * Builds a compact uppercase initialism for a team label.
+ *
+ * @param {string} teamName Team name entered by the user.
+ * @returns {string} Uppercase initials, or `T` when the name is empty.
+ */
 export function getTeamInitials(teamName) {
 	const tokens = normalizeToken(teamName)
 		.split(/[^A-Za-z0-9]+/)
@@ -12,6 +25,12 @@ export function getTeamInitials(teamName) {
 	return tokens.map((token) => token[0].toUpperCase()).join('');
 }
 
+/**
+ * Converts a zero-based index into spreadsheet-style alphabet labels.
+ *
+ * @param {number} index Zero-based player position.
+ * @returns {string} Label such as `A`, `B`, `Z`, `AA`, and so on.
+ */
 export function getAlphabetLabel(index) {
 	if (!Number.isInteger(index) || index < 0) {
 		return 'A';
@@ -25,21 +44,48 @@ export function getAlphabetLabel(index) {
 	return label;
 }
 
+/**
+ * Generates the default visible label for a player slot.
+ *
+ * @param {number} index Zero-based seat index on the team.
+ * @returns {string} Default name in the format `Player <Label>`.
+ */
 export function getDefaultPlayerName(index) {
 	return `Player ${getAlphabetLabel(index)}`;
 }
 
+/**
+ * Resolves a player's one-based team seat number.
+ *
+ * @param {{players: Array<{id: string}>}} team Team that owns the player.
+ * @param {string} playerId Player identifier to search for.
+ * @returns {number} One-based seat number or `0` when not found.
+ */
 export function getTeamPlayerNumber(team, playerId) {
 	const index = team.players.findIndex((player) => player.id === playerId);
 	return index >= 0 ? index + 1 : 0;
 }
 
+/**
+ * Returns a clean player name, falling back to the generated default for that seat.
+ *
+ * @param {{players: Array<{id: string}>}} team Team data that contains seat order.
+ * @param {{id: string, name: string}} player Player record to format.
+ * @returns {string} User-entered name when present, otherwise the default seat label.
+ */
 export function getPlayerBaseName(team, player) {
 	const playerNumber = getTeamPlayerNumber(team, player.id);
 	const defaultName = getDefaultPlayerName(Math.max(0, playerNumber - 1));
 	return normalizeToken(player.name) || defaultName;
 }
 
+/**
+ * Formats the fully-qualified display name shown throughout the UI.
+ *
+ * @param {{name: string, players: Array<{id: string}>}} team Team metadata.
+ * @param {{id: string, name: string}} player Player to render.
+ * @returns {string} Label in the format `<TEAM_INITIALS>-<seat> <player name>`.
+ */
 export function formatPlayerDisplayName(team, player) {
 	const initials = getTeamInitials(team.name);
 	const playerNumber = getTeamPlayerNumber(team, player.id);

--- a/src/lib/publish.js
+++ b/src/lib/publish.js
@@ -1,6 +1,12 @@
 import { calculateStandings } from './swiss.js';
 import { formatPlayerDisplayName } from './playerDisplay.js';
 
+/**
+ * Escapes HTML-sensitive characters to keep generated publish output safe.
+ *
+ * @param {unknown} value Raw value to escape.
+ * @returns {string} HTML-safe text content.
+ */
 function escapeHtml(value) {
 	return String(value)
 		.replaceAll('&', '&amp;')
@@ -10,10 +16,22 @@ function escapeHtml(value) {
 		.replaceAll("'", '&#39;');
 }
 
+/**
+ * Builds a quick lookup table for team IDs used while rendering rounds.
+ *
+ * @param {{teams: Array<{id: string}>}} event Event payload.
+ * @returns {Map<string, object>} Team map keyed by team identifier.
+ */
 function teamLookup(event) {
 	return new Map(event.teams.map((team) => [team.id, team]));
 }
 
+/**
+ * Generates a complete, standalone HTML export for standings and pairings.
+ *
+ * @param {object} event Event data model.
+ * @returns {string} A printable HTML document string.
+ */
 export function generatePublishedHtml(event) {
 	const standings = calculateStandings(event);
 	const teamsById = teamLookup(event);
@@ -96,6 +114,11 @@ export function generatePublishedHtml(event) {
 </html>`;
 }
 
+/**
+ * Downloads the generated event snapshot as a local HTML file.
+ *
+ * @param {object} event Event data model.
+ */
 export function downloadPublishedHtml(event) {
 	const html = generatePublishedHtml(event);
 	const blob = new Blob([html], { type: 'text/html' });

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,5 +1,10 @@
 const STORAGE_KEY = 'teamSwissEvents.v1';
 
+/**
+ * Loads persisted application state from localStorage.
+ *
+ * @returns {{events: Array<object>, activeEventId: string|null}} Parsed state, or a safe empty state on invalid/missing data.
+ */
 export function loadState() {
 	try {
 		const raw = localStorage.getItem(STORAGE_KEY);
@@ -19,10 +24,22 @@ export function loadState() {
 	}
 }
 
+/**
+ * Saves the full application state snapshot to localStorage.
+ *
+ * @param {{events: Array<object>, activeEventId: string|null}} state Serializable state object.
+ */
 export function saveState(state) {
 	localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
+/**
+ * Applies a mutation callback to persisted state and writes the result back.
+ *
+ * @template T
+ * @param {(state: {events: Array<object>, activeEventId: string|null}) => T} updateFn Callback that receives previous state.
+ * @returns {T} The value returned by `updateFn` after being persisted.
+ */
 export function withSavedState(updateFn) {
 	const previous = loadState();
 	const next = updateFn(previous);
@@ -30,6 +47,11 @@ export function withSavedState(updateFn) {
 	return next;
 }
 
+/**
+ * Exposes the internal storage namespace key for tests and diagnostics.
+ *
+ * @returns {string} Local storage key used for all persisted event data.
+ */
 export function getStorageKey() {
 	return STORAGE_KEY;
 }

--- a/src/lib/swiss.js
+++ b/src/lib/swiss.js
@@ -11,6 +11,12 @@ export const MAX_TEAM_COUNT = 16;
 export const MIN_PLAYERS_PER_TEAM = 1;
 export const MAX_PLAYERS_PER_TEAM = 8;
 
+/**
+ * Validates team and player-count boundaries for event creation/resizing.
+ *
+ * @param {number} teamCount Number of teams.
+ * @param {number} playersPerTeam Number of players on each team.
+ */
 function validateEventStructure(teamCount, playersPerTeam) {
 	if (!Number.isInteger(teamCount) || teamCount < MIN_TEAM_COUNT || teamCount > MAX_TEAM_COUNT) {
 		throw new Error(
@@ -28,6 +34,13 @@ function validateEventStructure(teamCount, playersPerTeam) {
 	}
 }
 
+/**
+ * Creates a new team skeleton with generated IDs and default player labels.
+ *
+ * @param {number} index Zero-based team index.
+ * @param {number} playersPerTeam Number of players to initialize.
+ * @returns {{id: string, name: string, players: Array<{id: string, name: string}>}} Team model.
+ */
 export function createTeam(index, playersPerTeam) {
 	return {
 		id: crypto.randomUUID(),
@@ -39,6 +52,12 @@ export function createTeam(index, playersPerTeam) {
 	};
 }
 
+/**
+ * Creates a new Swiss event with an initial roster and no rounds.
+ *
+ * @param {{name: string, teamCount: number, playersPerTeam: number}} params Event creation options.
+ * @returns {object} Event model.
+ */
 export function createEvent({ name, teamCount, playersPerTeam }) {
 	validateEventStructure(teamCount, playersPerTeam);
 	return {
@@ -85,6 +104,14 @@ function shuffle(values, rng) {
 	return shuffled;
 }
 
+/**
+ * Resizes team count and roster size while preserving existing IDs when possible.
+ * Existing rounds are cleared when structure changes.
+ *
+ * @param {object} event Existing event.
+ * @param {{teamCount: number, playersPerTeam: number}} options New structure options.
+ * @returns {object} Updated event.
+ */
 export function resizeEventStructure(event, { teamCount, playersPerTeam }) {
 	validateEventStructure(teamCount, playersPerTeam);
 
@@ -355,6 +382,14 @@ function tryPairPlayers(
 	return null;
 }
 
+/**
+ * Builds the next Swiss round pairing players across teams using standings and
+ * repeat-opponent avoidance heuristics.
+ *
+ * @param {object} event Event to pair.
+ * @param {{randomize?: boolean, rng?: () => number}} [options] Pairing options.
+ * @returns {object} Event copy with one appended round.
+ */
 export function generateNextRound(event, options = {}) {
 	const { randomize = false, rng = Math.random } = options;
 	const allPlayers = event.teams.flatMap((team) =>
@@ -453,6 +488,12 @@ function summarizeTeamMatch(match) {
 	return { teamAWins, teamBWins, gameWinsA, gameWinsB };
 }
 
+/**
+ * Calculates team standings and tie-breakers from all recorded rounds.
+ *
+ * @param {object} event Event with round results.
+ * @returns {Array<object>} Sorted standings table.
+ */
 export function calculateStandings(event) {
 	const table = new Map(
 		event.teams.map((team) => [
@@ -530,6 +571,14 @@ export function calculateStandings(event) {
 	});
 }
 
+/**
+ * Validates best-of-three per-seat score entry constraints.
+ *
+ * @param {number|string} winsA Games won by player A.
+ * @param {number|string} winsB Games won by player B.
+ * @param {number|string} [draws=0] Number of drawn games.
+ * @returns {boolean} True when values are non-negative integers within limits.
+ */
 export function validatePlayerMatchScore(winsA, winsB, draws = 0) {
 	const a = Number(winsA);
 	const b = Number(winsB);

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,7 @@
+/**
+ * Browser entry point for the Team Swiss Event Tracker UI.
+ * Manages in-memory UI state, persistence hooks, and DOM rendering/events.
+ */
 import { downloadPublishedHtml } from './lib/publish.js';
 import { loadState, saveState } from './lib/storage.js';
 import { assignPlayersToDraftTables, buildBalancedTableSizes } from './lib/draftTables.js';
@@ -35,15 +39,28 @@ if (!state.events.length) {
 	saveState(state);
 }
 
+/**
+ * Returns the event currently selected in application state.
+ *
+ * @returns {object|null} Active event or null when the selection is invalid.
+ */
 function getActiveEvent() {
 	return state.events.find((event) => event.id === state.activeEventId) ?? null;
 }
 
+/**
+ * Persists the current state snapshot and re-renders the UI.
+ */
 function persistAndRender() {
 	saveState(state);
 	render();
 }
 
+/**
+ * Applies a mutation callback to the active event and refreshes the interface.
+ *
+ * @param {(event: object) => object} mutator Pure transformation for active event data.
+ */
 function updateActiveEvent(mutator) {
 	const index = state.events.findIndex((event) => event.id === state.activeEventId);
 	if (index === -1) {
@@ -53,6 +70,12 @@ function updateActiveEvent(mutator) {
 	persistAndRender();
 }
 
+/**
+ * Produces a stable 32-bit hash for deterministic shuffle seeding.
+ *
+ * @param {string} value Input string to hash.
+ * @returns {number} Unsigned 32-bit hash value.
+ */
 function hashString(value) {
 	let hash = 2166136261;
 	for (const char of value) {
@@ -62,6 +85,12 @@ function hashString(value) {
 	return hash >>> 0;
 }
 
+/**
+ * Creates a deterministic pseudo-random number generator from a seed.
+ *
+ * @param {number} seed Integer seed.
+ * @returns {() => number} RNG function returning values in [0, 1).
+ */
 function createSeededRng(seed) {
 	let stateValue = seed >>> 0;
 	return () => {
@@ -72,6 +101,12 @@ function createSeededRng(seed) {
 	};
 }
 
+/**
+ * Checks whether any seat in a round has non-zero score input.
+ *
+ * @param {{matches: Array<{playerMatches: Array<{winsA?: number, winsB?: number, draws?: number}>}>}} round Round model.
+ * @returns {boolean} True when at least one score has been entered.
+ */
 function hasEnteredScores(round) {
 	return round.matches.some((match) =>
 		match.playerMatches.some(

--- a/tests/draftTables.test.js
+++ b/tests/draftTables.test.js
@@ -1,5 +1,5 @@
 /**
- * Integration-style unit tests for draftTables.test.
+ * Integration-style unit tests for the draftTables module.
  */
 import { describe, expect, it } from 'vitest';
 import { createEvent } from '../src/lib/swiss.js';

--- a/tests/draftTables.test.js
+++ b/tests/draftTables.test.js
@@ -1,3 +1,6 @@
+/**
+ * Integration-style unit tests for draftTables.test.
+ */
 import { describe, expect, it } from 'vitest';
 import { createEvent } from '../src/lib/swiss.js';
 import {
@@ -6,6 +9,12 @@ import {
 	listSuggestedDraftLayouts,
 } from '../src/lib/draftTables.js';
 
+/**
+ * Creates a deterministic RNG for reproducible randomized seating tests.
+ *
+ * @param {number} [seed=1] Seed used to initialize generator state.
+ * @returns {() => number} Deterministic RNG returning values in [0, 1).
+ */
 function createDeterministicRng(seed = 1) {
 	let stateValue = seed >>> 0;
 	return () => {
@@ -14,6 +23,9 @@ function createDeterministicRng(seed = 1) {
 	};
 }
 
+/**
+ * Validates draft table size suggestions and teammate-separation constraints.
+ */
 describe('draft table layouts', () => {
 	it('builds balanced table sizes for a chosen table count', () => {
 		expect(buildBalancedTableSizes(30, 4)).toEqual([8, 8, 7, 7]);

--- a/tests/playerDisplay.test.js
+++ b/tests/playerDisplay.test.js
@@ -1,3 +1,6 @@
+/**
+ * Integration-style unit tests for playerDisplay.test.
+ */
 import { describe, expect, it } from 'vitest';
 import {
 	formatPlayerDisplayName,
@@ -6,6 +9,9 @@ import {
 	getTeamInitials,
 } from '../src/lib/playerDisplay.js';
 
+/**
+ * Verifies player display helper formatting behavior and fallback naming.
+ */
 describe('player display formatting', () => {
 	it('builds team initials from team name', () => {
 		expect(getTeamInitials('Team Swiss Event Tracker')).toBe('TSET');

--- a/tests/playerDisplay.test.js
+++ b/tests/playerDisplay.test.js
@@ -1,5 +1,5 @@
 /**
- * Integration-style unit tests for playerDisplay.test.
+ * Integration-style unit tests for the playerDisplay module.
  */
 import { describe, expect, it } from 'vitest';
 import {

--- a/tests/swiss.test.js
+++ b/tests/swiss.test.js
@@ -1,3 +1,6 @@
+/**
+ * Integration-style unit tests for swiss.test.
+ */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	calculateStandings,
@@ -21,6 +24,9 @@ function createDeterministicRng(seed = 7) {
 	};
 }
 
+/**
+ * Exercises Swiss pairing, standings, validation, and related utilities.
+ */
 describe('swiss event engine', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -183,6 +189,9 @@ describe('swiss event engine', () => {
 	});
 });
 
+/**
+ * Covers storage persistence and publishable HTML snapshot generation.
+ */
 describe('storage and publish utilities', () => {
 	beforeEach(() => {
 		localStorage.clear();

--- a/tests/swiss.test.js
+++ b/tests/swiss.test.js
@@ -1,5 +1,5 @@
 /**
- * Integration-style unit tests for swiss.test.
+ * Integration-style unit tests for the swiss module.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {


### PR DESCRIPTION
### Motivation
- Improve code readability and maintenance by adding comprehensive JSDoc to library modules and tests so tooling and new contributors can understand contracts and behavior.
- Produce accurate test coverage (including branch coverage) for the project by enabling a V8-based coverage provider for Vitest.

### Description
- Added JSDoc comments to source modules (`src/main.js`, `src/lib/swiss.js`, `src/lib/draftTables.js`, `src/lib/playerDisplay.js`, `src/lib/publish.js`, `src/lib/storage.js`) describing purpose, parameters, and return values for key helpers and exported APIs.
- Annotated test files (`tests/swiss.test.js`, `tests/draftTables.test.js`, `tests/playerDisplay.test.js`) with suite-level descriptions and deterministic RNG helper documentation to clarify intent; these are documentation-only changes and do not alter behavior.
- Added the version-compatible `@vitest/coverage-v8` dev dependency and updated lockfile so Vitest can emit V8-based coverage and branch information during test runs.
- No functional logic changes were made to algorithms; changes are limited to comments, test annotations, and the coverage tooling dependency.

### Testing
- Ran `npm test -- --coverage` and observed all test files pass (`3 files`, `21 tests` passed) and a V8 coverage report produced; summary: Statements 58.14%, Branches 77.63%, Functions 92.30%, Lines 58.14%.
- Ran `npm run lint` which completed without errors.
- The HTML/text coverage artifacts are generated by the test run and available in the test output (and the Vite/Vitest coverage report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c74b0878083298324ce0da0e1015f)